### PR TITLE
Fix Button dinamic variant styles

### DIFF
--- a/packages/genesys/packages/react-native-components/package.json
+++ b/packages/genesys/packages/react-native-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peersyst/react-native-components",
     "author": "Peersyst",
-    "version": "1.2.21",
+    "version": "1.2.22",
     "license": "MIT",
     "main": "./src/index.tsx",
     "engines": {

--- a/packages/genesys/packages/react-native-components/src/input/Button/Button.types.ts
+++ b/packages/genesys/packages/react-native-components/src/input/Button/Button.types.ts
@@ -5,7 +5,7 @@ import { ButtonVariant, CoreButtonProps } from "@peersyst/react-components-core"
 
 export type ButtonStyle = ViewStyle & TextStyle;
 export type ButtonVariantStyle = Partial<Record<ButtonVariant, ButtonStyle>>;
-export type ButtonStyleWithVariant = ButtonStyle & ButtonVariantStyle;
+export type ButtonStyleWithVariant = ButtonStyle & { variant?: ButtonVariantStyle };
 
 export interface ButtonSizeStyle {
     sm?: ButtonStyle;

--- a/packages/genesys/packages/react-native-components/src/input/Button/hooks/useButtonStyles.ts
+++ b/packages/genesys/packages/react-native-components/src/input/Button/hooks/useButtonStyles.ts
@@ -20,18 +20,8 @@ export default function useButtonStyles(
     const { defaultStyles, defaultDisabledStyles, defaultPressedStyles, defaultSizeStyles } =
         useDefaultStyles();
     const {
-        disabled: {
-            filled: filledDisabledStyles,
-            text: textDisabledStyles,
-            outlined: outlinedDisabledText,
-            ...disabledStyles
-        } = {},
-        pressed: {
-            filled: filledPressedStyles,
-            text: textPressedStyles,
-            outlined: outlinedPressedText,
-            ...pressedStyles
-        } = {},
+        disabled: { variant: variantDisabledStyles, ...disabledStyles } = {},
+        pressed: { variant: variantPressedStyles, ...pressedStyles } = {},
         ...styles
     } = style;
 
@@ -45,22 +35,11 @@ export default function useButtonStyles(
     );
 
     const [variantDisabledTextStyles, variantDisabledRootStyles] = useMemo(() => {
-        const disabledVariantStyles = {
-            filled: filledDisabledStyles,
-            text: textDisabledStyles,
-            outlined: outlinedDisabledText,
-        };
         return extractTextStyles({
-            ...defaultDisabledStyles[variant],
-            ...disabledVariantStyles[variant],
+            ...defaultDisabledStyles.variant?.[variant],
+            ...variantDisabledStyles?.[variant],
         });
-    }, [
-        filledDisabledStyles,
-        defaultDisabledStyles,
-        outlinedDisabledText,
-        textDisabledStyles,
-        variant,
-    ]);
+    }, [variantDisabledStyles, defaultDisabledStyles, variant]);
 
     const [pressedTextStyles, pressedRootStyles] = useMemo(
         () => extractTextStyles({ ...defaultPressedStyles, ...pressedStyles }),
@@ -68,25 +47,18 @@ export default function useButtonStyles(
     );
 
     const [variantPressedTextStyles, variantPressedRootStyles] = useMemo(() => {
-        const pressedVariantStyles = {
-            filled: filledPressedStyles,
-            text: textPressedStyles,
-            outlined: outlinedPressedText,
-        };
         return extractTextStyles({
-            ...defaultPressedStyles[variant],
-            ...pressedVariantStyles[variant],
+            ...defaultPressedStyles.variant?.[variant],
+            ...variantPressedStyles?.[variant],
         });
-    }, [
-        filledPressedStyles,
-        defaultPressedStyles,
-        outlinedPressedText,
-        textPressedStyles,
-        variant,
-    ]);
+    }, [variantPressedStyles, defaultPressedStyles, variant]);
 
     const [variantTextStyles, variantRootStyles] = useMemo(
-        () => extractTextStyles({ ...defaultStyles[variant], ...styles[variant] }),
+        () =>
+            extractTextStyles({
+                ...defaultStyles.variant?.[variant],
+                ...styles.variant?.[variant],
+            }),
         [defaultStyles, styles, variant],
     );
 

--- a/packages/genesys/packages/react-native-components/src/input/Button/hooks/useDefaultStyles.ts
+++ b/packages/genesys/packages/react-native-components/src/input/Button/hooks/useDefaultStyles.ts
@@ -15,39 +15,45 @@ export default function (): UseDefaultStylesResult {
     const defaultStyles: ButtonStyleWithVariant = {
         backgroundColor: "transparent",
         color: theme.palette.primary,
-        filled: {
-            backgroundColor: theme.palette.primary,
-            color: theme.palette.text,
-        },
-        outlined: {
-            borderStyle: "solid",
-            borderWidth: 2,
-            borderColor: theme.palette.primary,
-        },
-        text: {
-            borderColor: "transparent",
+        variant: {
+            filled: {
+                backgroundColor: theme.palette.primary,
+                color: theme.palette.text,
+            },
+            outlined: {
+                borderStyle: "solid",
+                borderWidth: 2,
+                borderColor: theme.palette.primary,
+            },
+            text: {
+                borderColor: "transparent",
+            },
         },
     };
 
     const defaultDisabledStyles: ButtonStyleWithVariant = {
         color: theme.palette.disabled,
-        filled: {
-            backgroundColor: theme.palette.disabled,
-            color: emphasize(theme.palette.disabled, 0.5),
-        },
-        outlined: {
-            borderColor: theme.palette.disabled,
+        variant: {
+            filled: {
+                backgroundColor: theme.palette.disabled,
+                color: emphasize(theme.palette.disabled, 0.5),
+            },
+            outlined: {
+                borderColor: theme.palette.disabled,
+            },
         },
     };
 
     const defaultPressedStyles: ButtonStyleWithVariant = {
         backgroundColor: alpha(theme.palette.primary, 0.2),
-        filled: {
-            backgroundColor: darken(theme.palette.primary, 0.1),
-        },
-        text: {
-            backgroundColor: "transparent",
-            textDecorationLine: "underline",
+        variant: {
+            filled: {
+                backgroundColor: darken(theme.palette.primary, 0.1),
+            },
+            text: {
+                backgroundColor: "transparent",
+                textDecorationLine: "underline",
+            },
         },
     };
 


### PR DESCRIPTION
# Button Generic Variant Styles

## Issues

closes #95 

## Changes

* Add variant style that includes all variants instead of including all variants in the style directly, in order to allow dynamic variant styles. That's because the variant name has to be known in order to extract it from a raw style. In our case this is not possible, as variants can be changed through the theme