### PR TITLE
Fix BlockchainAddresCopy

### DIFF
--- a/packages/genesys/packages/react-native-components/CHANGELOG.md
+++ b/packages/genesys/packages/react-native-components/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Versions
 
+## 2.0.11
+
+[CopyButton] Fix copy to clipboard setString deprecated. Now use setStringAsync (only async on web)
+[BlockchainAddress] Enable not displaying the copy button
+
 ## 2.0.2
 
 [Select] Add testID to select display touchable

--- a/packages/genesys/packages/react-native-components/package.json
+++ b/packages/genesys/packages/react-native-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peersyst/react-native-components",
     "author": "Peersyst",
-    "version": "2.0.10",
+    "version": "2.0.11",
     "license": "MIT",
     "main": "./src/index.tsx",
     "engines": {
@@ -46,7 +46,7 @@
         "@react-native-community/hooks": "^2.8.1",
         "expo-barcode-scanner": "^11.2.1",
         "expo-camera": "~12.1.2",
-        "expo-clipboard": "~2.1.0",
+        "expo-clipboard": "~4.0.1",
         "expo-constants": "~13.0.2",
         "expo-localization": "~12.0.0",
         "expo-status-bar": "^1.2.0",

--- a/packages/genesys/packages/react-native-components/src/util/BlockchainAddress/BlockchainAddress.tsx
+++ b/packages/genesys/packages/react-native-components/src/util/BlockchainAddress/BlockchainAddress.tsx
@@ -13,7 +13,7 @@ import {
 } from "@peersyst/react-components-core";
 
 const BlockchainAddress = (props: BlockchainAddressProps): JSX.Element => {
-    const { address, ellipsis, type, length, style, variant, ...typographyProps } =
+    const { address, ellipsis, type, length, style, copy, variant, ...typographyProps } =
         useMergeDefaultProps("BlockchainAddress", props);
 
     const { typography } = useTheme();
@@ -30,7 +30,7 @@ const BlockchainAddress = (props: BlockchainAddressProps): JSX.Element => {
 
     return (
         <Row alignItems="center" gap={10} style={rootStyle}>
-            <TouchableOpacity onPress={openExplorer}>
+            <TouchableOpacity onPress={copy ? openExplorer : () => void 0}>
                 <Typography
                     numberOfLines={1}
                     style={textStyle}
@@ -40,11 +40,13 @@ const BlockchainAddress = (props: BlockchainAddressProps): JSX.Element => {
                     {formatHash(address, ellipsis, length)}
                 </Typography>
             </TouchableOpacity>
-            <CopyButton
-                text={address}
-                message={translate("copied_to_clipboard")}
-                style={{ ...typographyVariantStyles, ...textStyle, fontSize: copyFontSize }}
-            />
+            {copy && (
+                <CopyButton
+                    text={address}
+                    message={translate("copied_to_clipboard")}
+                    style={{ ...typographyVariantStyles, ...textStyle, fontSize: copyFontSize }}
+                />
+            )}
         </Row>
     );
 };

--- a/packages/genesys/packages/react-native-components/src/util/BlockchainAddress/BlockchainAddress.types.ts
+++ b/packages/genesys/packages/react-native-components/src/util/BlockchainAddress/BlockchainAddress.types.ts
@@ -24,4 +24,8 @@ export interface BlockchainAddressProps
      * If ellipsis should be in the middle or end
      */
     ellipsis?: HashEllipsis;
+    /**
+     * Show Icon copy
+     */
+    copy?: boolean;
 }

--- a/packages/genesys/packages/react-native-components/src/util/CopyButton/CopyButton.tsx
+++ b/packages/genesys/packages/react-native-components/src/util/CopyButton/CopyButton.tsx
@@ -11,7 +11,7 @@ const CopyButton = (props: CopyButtonProps): JSX.Element => {
     const { showToast } = useToast();
 
     const copyToClipboard = () => {
-        Clipboard.setString(text);
+        Clipboard.setStringAsync(text);
         if (message) showToast(message, { type: "success" });
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7949,10 +7949,10 @@ expo-camera@~12.1.2:
     "@koale/useworker" "^4.0.2"
     invariant "^2.2.4"
 
-expo-clipboard@~2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/expo-clipboard/-/expo-clipboard-2.1.1.tgz#77a506eb70918e6a4708760e6cfb0fafdc18192d"
-  integrity sha512-ay4zv7JGIWT/lqFsonWK8BQ4FuMLaSNFg5gaYJQcIZgZoCyF9f7GRh1HrV3tA0rCPA3i9T6Kt8/8vMMrraH9RQ==
+expo-clipboard@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/expo-clipboard/-/expo-clipboard-4.0.1.tgz#74385c2deacbfc75583ebb22e95067bd8f79a037"
+  integrity sha512-ikVitSk8ltbbdmufQE/7+BpkDFU1hsLw5lhjEqknG6PHjtn4TP+ypMxKobBftU2VpFiz9O09bpRt86E8CzsJgQ==
 
 expo-constants@~13.0.2:
   version "13.0.2"


### PR DESCRIPTION
Changes
- [CopyButton] Fix copy to clipboard setString deprecated. Now use setStringAsync (only async on web)
- [BlockchainAddress] Enable not displaying the copy button