### PR TITLE
[RC] Add `PointerFormControl` to `RadioButton`

### DIFF
--- a/packages/genesys/packages/react-components/package.json
+++ b/packages/genesys/packages/react-components/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peersyst/react-components",
     "author": "Peersyst",
-    "version": "3.9.24",
+    "version": "3.9.25",
     "license": "MIT",
     "main": "./src/index.tsx",
     "engines": {

--- a/packages/genesys/packages/react-components/src/RadioButton/RadioButton.tsx
+++ b/packages/genesys/packages/react-components/src/RadioButton/RadioButton.tsx
@@ -3,9 +3,9 @@ import { RadioButtonProps } from "./RadioButton.types";
 import { cx } from "@peersyst/react-utils";
 import { RadioCheckedIcon, RadioUncheckedIcon } from "../assets/icons";
 import { Label } from "../Label";
-import { FormControl } from "../FormControl";
 import { useMergeDefaultProps } from "@peersyst/react-components-core";
 import { useRef } from "react";
+import PointerFormControl from "../common/PointerFormControl";
 
 export default function RadioButton(props: RadioButtonProps) {
     const {
@@ -26,7 +26,7 @@ export default function RadioButton(props: RadioButtonProps) {
     };
 
     return (
-        <FormControl<boolean>
+        <PointerFormControl<boolean>
             Label={[LabelProp, { placement: "right", ...LabelProps }]}
             defaultValue={defaultValue}
             disabled={disabled}
@@ -46,6 +46,6 @@ export default function RadioButton(props: RadioButtonProps) {
                     {value ? checkedIcon : icon}
                 </RadioButtonRoot>
             )}
-        </FormControl>
+        </PointerFormControl>
     );
 }


### PR DESCRIPTION
# [RC] Add `PointerFormControl` to `RadioButton`

## Changes :hammer_and_wrench:

### react-components

- Add `PointerFormControl` to `RadioButton`
